### PR TITLE
Update the function signature of api.newrelic.errorReporter to match current format

### DIFF
--- a/initializers/newrelic.js
+++ b/initializers/newrelic.js
@@ -11,7 +11,7 @@ module.exports = {
         next();
       },
 
-      errorReporter: function(type, err, extraMessages, severity){
+      errorReporter: function(err, type, name, objects, severity){
         newrelic.noticeError(err);
       }
     };


### PR DESCRIPTION
The function signature for calling api.newrelic.errorReporter changed in [this commit](https://github.com/evantahler/actionhero/commit/6f48c148c3ea2145c972f4188c37462bb0456019#diff-478a7553f15898ef8e674e457d7a80d7R54).  The work in this PR adjusts api.newrelic.errorReporter to match.